### PR TITLE
Add "windows" to linebreak-style in eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,7 @@
     "handle-callback-err": ["error"],
     "arrow-body-style": ["off", 2],
     "indent": ["off", 2],
-    "linebreak-style": ["error", "unix"],
+    "linebreak-style": ["error", "unix", "windows"],
     "no-dupe-keys": ["error"],
     "no-duplicate-case": ["error"],
     "no-extra-semi": ["warn"],


### PR DESCRIPTION
So no errors about line endings appear in Windows environments.